### PR TITLE
BE71 Add seat reservation/release for training classes

### DIFF
--- a/Data/Interfaces/ITrainingClassRepository.cs
+++ b/Data/Interfaces/ITrainingClassRepository.cs
@@ -4,4 +4,17 @@ namespace Data.Interfaces;
 
 public interface ITrainingClassRepository : IBaseRepository<TrainingClassEntity>
 {
+    /// <summary>
+    /// Försöker reservera ett antal platser för en klass.
+    /// Returnerar false om klassen inte finns, om det blir överkapacitet
+    /// eller om en concurrency-konflikt inträffar.
+    /// </summary>
+    Task<bool> TryReserveSeatsAsync(int classId, int seats, CancellationToken ct = default);
+
+    /// <summary>
+    /// Försöker släppa (minska) ett antal reserverade platser.
+    /// Returnerar false om klassen inte finns eller vid concurrency-konflikt.
+    /// Antalet reserverade platser understiger aldrig noll.
+    /// </summary>
+    Task<bool> TryReleaseSeatsAsync(int classId, int seats, CancellationToken ct = default);
 }

--- a/Data/Repositories/TrainingClassRepository.cs
+++ b/Data/Repositories/TrainingClassRepository.cs
@@ -1,11 +1,54 @@
 ﻿using Data.Contexts;
 using Data.Entities;
 using Data.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace Data.Repositories;
 
 public class TrainingClassRepository(DataContext context)
     : BaseRepository<TrainingClassEntity>(context), ITrainingClassRepository
 {
+    public async Task<bool> TryReserveSeatsAsync(int classId, int seats, CancellationToken ct = default)
+    {
+        if (seats <= 0) return false;
 
+        var entity = await _context.TrainingClasses
+            .FirstOrDefaultAsync(x => x.Id == classId, ct);
+        if (entity is null) return false;
+
+        if (entity.ReservedSeats + seats > entity.Capacity) return false;
+
+        entity.ReservedSeats += seats;
+
+        try
+        {
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return false;
+        }
+    }
+
+    public async Task<bool> TryReleaseSeatsAsync(int classId, int seats, CancellationToken ct = default)
+    {
+        if (seats <= 0) return false;
+
+        var entity = await _context.TrainingClasses
+            .FirstOrDefaultAsync(x => x.Id == classId, ct);
+        if (entity is null) return false;
+
+        entity.ReservedSeats = Math.Max(0, entity.ReservedSeats - seats);
+
+        try
+        {
+            await _context.SaveChangesAsync(ct);
+            return true;
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return false;
+        }
+    }
 }

--- a/Infrastructure/Dtos/TrainingClassDto.cs
+++ b/Infrastructure/Dtos/TrainingClassDto.cs
@@ -16,5 +16,6 @@ public class TrainingClassDto
     public string Location { get; set; } = string.Empty;
     public string Instructor { get; set; } = string.Empty;
     public int Capacity { get; set; }
+    public int ReservedSeats { get; set; }
 
 }

--- a/eventsystem/Controllers/TrainingClassSeatsController.cs
+++ b/eventsystem/Controllers/TrainingClassSeatsController.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Data.Interfaces;
+
+namespace eventsystem.Controllers;
+
+
+[ApiController]
+[Route("api/trainingclasses/{id:int}/seats")]
+public class TrainingClassSeatsController(ITrainingClassRepository repo) : ControllerBase
+{
+    private readonly ITrainingClassRepository _repo = repo;
+    public record SeatsRequest(int Seats = 1);
+
+    [HttpPost("reserve")]
+    public async Task<IActionResult> Reserve(int id, [FromBody] SeatsRequest req, CancellationToken ct)
+    {
+        var seats = Math.Max(1, req?.Seats ?? 1);
+        if (!await _repo.ExistsAsync(x => x.Id == id, ct))
+            return NotFound(new { message = "Klassen finns inte." });
+
+        var ok = await _repo.TryReserveSeatsAsync(id, seats, ct);
+        if (ok) return Ok();
+        return Conflict(new { message = "Kunde inte reservera plats (fullt eller concurrency-konflikt)." });
+    }
+
+    [HttpPost("release")]
+    public async Task<IActionResult> Release(int id, [FromBody] SeatsRequest req, CancellationToken ct)
+    {
+        var seats = Math.Max(1, req?.Seats ?? 1);
+        if (!await _repo.ExistsAsync(x => x.Id == id, ct))
+            return NotFound(new { message = "Klassen finns inte." });
+
+        var ok = await _repo.TryReleaseSeatsAsync(id, seats, ct);
+        if (ok) return Ok();
+        return Conflict(new { message = "Kunde inte släppa plats (concurrency-konflikt)." });
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces first-class seat management in EventService so the Booking service can safely reserve/release seats without oversubscription under concurrent load.

### What changed

**Repository & Interface**

ITrainingClassRepository

Added:
- Task<bool> TryReserveSeatsAsync(int classId, int seats, CancellationToken ct = default)
- Task<bool> TryReleaseSeatsAsync(int classId, int seats, CancellationToken ct = default)

TrainingClassRepository

- Implements the two methods using tracked entities + RowVersion as concurrency token.
- Validates seats > 0.
- Ensures capacity is not exceeded on reserve.
- Ensures ReservedSeats never drops below zero on release.
- On concurrent updates, catches DbUpdateConcurrencyException and returns false.

**API**

TrainingClassSeatsController

- POST /api/trainingclasses/{id:int}/seats/reserve
- Body: { "Seats": 1 } (defaults to ≥ 1)

Returns:
200 OK on success
404 Not Found if class doesn’t exist
409 Conflict if full or a concurrency conflict occurs

- POST /api/trainingclasses/{id:int}/seats/release
- Body: { "Seats": 1 }

Returns 200/404/409 as above
Introduces SeatsRequest record and enforces a minimum of 1 seat.

**DTO**

TrainingClassDto
Updated to include ReservedSeats (useful for diagnostics/ops; non-breaking).

**Misc**
Controller remains thin; business rules centralized in the repository.

### Why

To support bookings across two microservices without table “stampedes.” Using EF Core’s optimistic concurrency (via RowVersion) ensures only one writer wins when two clients try to reserve the last seat at the same time. The loser receives a 409 Conflict and can retry/back off.

### Impact after merging to dev

EventService exposes stable endpoints for seat reservation/release with concurrency protection.

