### PR TITLE
Added GetAll in Service with proper Interface and Controller

### DIFF
--- a/Infrastructure/Interfaces/ITrainingClassService.cs
+++ b/Infrastructure/Interfaces/ITrainingClassService.cs
@@ -4,6 +4,7 @@ namespace Infrastructure.Interfaces
 {
     public interface ITrainingClassService
     {
+        Task<List<TrainingClassDto>> GetAllTrainingClassesAsync(CancellationToken ct = default);
         Task<TrainingClassDto?> GetTrainingClassByIdAsync(int id, CancellationToken ct = default);
     }
 }

--- a/Infrastructure/Services/TrainingClassService.cs
+++ b/Infrastructure/Services/TrainingClassService.cs
@@ -40,4 +40,27 @@ public class TrainingClassService(ITrainingClassRepository trainingRepository) :
         return dto;
     }
 
+    public async Task<List<TrainingClassDto>> GetAllTrainingClassesAsync(CancellationToken ct = default)
+    {
+        // Hämta entity från repository
+        var result = await _trainingRepository.GetAllAsync(ct);
+
+        // Om anropet misslyckades eller resultatet är null
+        if (!result.Succeeded || result.Result == null)
+            return new List<TrainingClassDto>();
+
+        // Mappa entity till DTO
+        return result.Result.Select(x => new TrainingClassDto
+        {
+            Id = x.Id,
+            Title = x.Title,
+            Description = x.Description,
+            StartTime = x.StartTime,
+            EndTime = x.EndTime,
+            Location = x.Location,
+            Instructor = x.Instructor,
+            Capacity = x.Capacity
+        }).ToList();
+    }
+
 }

--- a/eventsystem/Controllers/EventController.cs
+++ b/eventsystem/Controllers/EventController.cs
@@ -23,4 +23,14 @@ public class EventController(ITrainingClassService trainingClassService) : Contr
         return Ok(trainingClass);
     }
 
+    [HttpGet]
+    public async Task<IActionResult> GetAll(CancellationToken ct)
+    {
+        var classes = await _trainingClassService.GetAllTrainingClassesAsync(ct);
+        if (classes == null)
+            return NotFound();
+
+        return Ok(classes);
+    }
+
 }


### PR DESCRIPTION
New method in "TrainingClassService" named "GetAllTrainingClassesAsync"
 - Get all TrainingClass entites with help from repository
 - maps entities to dtos
 - returns empty list if no list exists
 
New endpoint in "TrainingClassController" named  "GetAll"
 - Calls for the service method "GetAllTrainingClassesAsync"
 - Returns "Ok" if found and "NotFound" if result is null
 
 With this we can get all TrainingClasses listed with the API. 
 Frotend call ***/api/Event
 
 Doesn't affect any existing methods
 
 
<img width="1146" height="850" alt="image" src="https://github.com/user-attachments/assets/46855224-9b5b-4afd-8262-7bb3023c9549" />


