### PR TITLE
Route seat operations through Service layer (include concurrency) — no behavior change

### DIFF
--- a/Infrastructure/Interfaces/ITrainingClassService.cs
+++ b/Infrastructure/Interfaces/ITrainingClassService.cs
@@ -1,10 +1,12 @@
 ﻿using Infrastructure.Dtos;
 
-namespace Infrastructure.Interfaces
+namespace Infrastructure.Interfaces;
+
+public interface ITrainingClassService
 {
-    public interface ITrainingClassService
-    {
-        Task<List<TrainingClassDto>> GetAllTrainingClassesAsync(CancellationToken ct = default);
-        Task<TrainingClassDto?> GetTrainingClassByIdAsync(int id, CancellationToken ct = default);
-    }
+    Task<List<TrainingClassDto>> GetAllTrainingClassesAsync(CancellationToken ct = default);
+    Task<TrainingClassDto?> GetTrainingClassByIdAsync(int id, CancellationToken ct = default);
+
+    Task<bool> TryReserveSeatsAsync(int classId, int seats, CancellationToken ct = default);
+    Task<bool> TryReleaseSeatsAsync(int classId, int seats, CancellationToken ct = default);
 }

--- a/Infrastructure/Services/TrainingClassService.cs
+++ b/Infrastructure/Services/TrainingClassService.cs
@@ -1,11 +1,6 @@
 ﻿using Data.Interfaces;
 using Infrastructure.Dtos;
 using Infrastructure.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Infrastructure.Services;
 
@@ -17,14 +12,11 @@ public class TrainingClassService(ITrainingClassRepository trainingRepository) :
 
     public async Task<TrainingClassDto?> GetTrainingClassByIdAsync(int id, CancellationToken ct = default)
     {
-        // Hämta entity från repository
         var result = await _trainingRepository.GetByIdAsync(id, ct);
 
-        // Om anropet misslyckades eller resultatet är null
         if (!result.Succeeded || result.Result == null)
             return null;
 
-        // Mappa entity till DTO
         var dto = new TrainingClassDto
         {
             Id = result.Result.Id,
@@ -42,14 +34,11 @@ public class TrainingClassService(ITrainingClassRepository trainingRepository) :
 
     public async Task<List<TrainingClassDto>> GetAllTrainingClassesAsync(CancellationToken ct = default)
     {
-        // Hämta entity från repository
         var result = await _trainingRepository.GetAllAsync(ct);
 
-        // Om anropet misslyckades eller resultatet är null
         if (!result.Succeeded || result.Result == null)
             return new List<TrainingClassDto>();
 
-        // Mappa entity till DTO
         return result.Result.Select(x => new TrainingClassDto
         {
             Id = x.Id,
@@ -62,5 +51,11 @@ public class TrainingClassService(ITrainingClassRepository trainingRepository) :
             Capacity = x.Capacity
         }).ToList();
     }
+
+    public async Task<bool> TryReserveSeatsAsync(int classId, int seats, CancellationToken ct = default)
+        => await _trainingRepository.TryReserveSeatsAsync(classId, seats, ct);
+
+    public async Task<bool> TryReleaseSeatsAsync(int classId, int seats, CancellationToken ct = default)
+        => await _trainingRepository.TryReleaseSeatsAsync(classId, seats, ct);
 
 }

--- a/eventsystem/Controllers/TrainingClassSeatsController.cs
+++ b/eventsystem/Controllers/TrainingClassSeatsController.cs
@@ -1,37 +1,40 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Data.Interfaces;
+using Infrastructure.Interfaces;
 
 namespace eventsystem.Controllers;
 
 
 [ApiController]
 [Route("api/trainingclasses/{id:int}/seats")]
-public class TrainingClassSeatsController(ITrainingClassRepository repo) : ControllerBase
+public class TrainingClassSeatsController(ITrainingClassService service) : ControllerBase
 {
-    private readonly ITrainingClassRepository _repo = repo;
+    private readonly ITrainingClassService _service = service;
     public record SeatsRequest(int Seats = 1);
 
     [HttpPost("reserve")]
     public async Task<IActionResult> Reserve(int id, [FromBody] SeatsRequest req, CancellationToken ct)
     {
         var seats = Math.Max(1, req?.Seats ?? 1);
-        if (!await _repo.ExistsAsync(x => x.Id == id, ct))
+        if (await _service.GetTrainingClassByIdAsync(id, ct) == null)
             return NotFound(new { message = "Klassen finns inte." });
 
-        var ok = await _repo.TryReserveSeatsAsync(id, seats, ct);
-        if (ok) return Ok();
-        return Conflict(new { message = "Kunde inte reservera plats (fullt eller concurrency-konflikt)." });
+        var ok = await _service.TryReserveSeatsAsync(id, seats, ct);
+        return ok
+            ? Ok()
+            : Conflict(new { message = "Kunde inte reservera plats (fullt eller concurrency-konflikt)." });
     }
 
     [HttpPost("release")]
     public async Task<IActionResult> Release(int id, [FromBody] SeatsRequest req, CancellationToken ct)
     {
         var seats = Math.Max(1, req?.Seats ?? 1);
-        if (!await _repo.ExistsAsync(x => x.Id == id, ct))
+        if (await _service.GetTrainingClassByIdAsync(id, ct) == null)
             return NotFound(new { message = "Klassen finns inte." });
 
-        var ok = await _repo.TryReleaseSeatsAsync(id, seats, ct);
-        if (ok) return Ok();
-        return Conflict(new { message = "Kunde inte släppa plats (concurrency-konflikt)." });
+        var ok = await _service.TryReleaseSeatsAsync(id, seats, ct);
+        return ok
+            ? Ok()
+            : Conflict(new { message = "Kunde inte släppa plats (concurrency-konflikt)." });
     }
 }


### PR DESCRIPTION
### Summary

This PR introduces the service layer into our seat-reservation workflow while keeping the existing concurrency handling intact. Controllers now depend on ITrainingClassService instead of the repository, aligning with our standard architectural pattern (Controller → Service → Repository).

### What changed

ITrainingClassService

**Added:**
Task<bool> TryReserveSeatsAsync(int classId, int seats, CancellationToken ct = default);
Task<bool> TryReleaseSeatsAsync(int classId, int seats, CancellationToken ct = default);

_TrainingClassService_
Implemented the two methods above, delegating to _trainingRepository so EF Core concurrency (RowVersion + DbUpdateConcurrencyException) continues to be handled in the repository.

_TrainingClassSeatsController_
Switched DI from ITrainingClassRepository → ITrainingClassService.

Uses the service for:
Existence check (GetTrainingClassByIdAsync)
Seat operations (TryReserveSeatsAsync / TryReleaseSeatsAsync)
Routes and response codes are unchanged.

### Why

Consistency: other endpoints already use the service layer; seats were the outlier.
Clarity for the team: a single entrypoint for domain operations.
Minimal change: we don’t move concurrency logic; we only expose it via the service.

### Impact on development upon Merge

Runtime behavior: No functional change expected. Booking logic, routes, payloads, and status codes remain the same.
Concurrency: Still enforced by EF Core via RowVersion; exceptions are handled as before (returns 409 Conflict on clashes).